### PR TITLE
feat: Enhance Home and Favorites screens with new UI and filtering

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,9 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.MyApplication">
+            android:theme="@style/Theme.MyApplication"
+            android:screenOrientation="portrait">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -22,4 +22,4 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
-}
+

--- a/app/src/main/java/com/example/myapplication/model/Place.kt
+++ b/app/src/main/java/com/example/myapplication/model/Place.kt
@@ -15,7 +15,11 @@ data class Place(
     val schedules: List<Schedule>,
     val createdByUserId: String? = null,
     val createdAt: LocalDateTime = LocalDateTime.now(),
-    val status: ReviewStatus = ReviewStatus.PENDING
+    val status: ReviewStatus = ReviewStatus.PENDING,
+    val distanceKm: Double? = null,
+    val puntuation: Double? = null
+
+
 ){
 
     fun isOpen():Boolean{

--- a/app/src/main/java/com/example/myapplication/ui/components/HomeSlipBarCard.kt
+++ b/app/src/main/java/com/example/myapplication/ui/components/HomeSlipBarCard.kt
@@ -1,10 +1,12 @@
 package com.example.myapplication.ui.components
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -15,7 +17,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButtonDefaults.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -23,35 +24,40 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.example.myapplication.R
+import com.example.myapplication.model.PlaceType
 
 @Composable
-fun slipCard(
+fun SlipCard(
     name: String,
-    description: String,
+    type: PlaceType,
     imageUrl: String,
+    puntuation: Double?,
+    distance: Double,
     onClick: () -> Unit
 ) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .padding(horizontal = 9.dp, vertical = 2.dp)
+            .border(2.dp, Color.Gray, RoundedCornerShape(12.dp))
             .clickable { onClick() },
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = Color.White
-        ),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Row(
             modifier = Modifier
                 .padding(12.dp)
+                .height(80.dp)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Imagen del sitio
+
             AsyncImage(
                 model = imageUrl,
                 contentDescription = null,
@@ -63,7 +69,6 @@ fun slipCard(
 
             Spacer(modifier = Modifier.width(12.dp))
 
-            // Nombre y descripción
             Column(
                 modifier = Modifier.weight(1f)
             ) {
@@ -71,23 +76,24 @@ fun slipCard(
                     text = name,
                     style = MaterialTheme.typography.bodyLarge.copy(
                         fontWeight = FontWeight.Medium,
-                        color = Color(0xFF1B1C1E)
+                        color = Color.Black
                     )
                 )
 
                 Text(
-                    text = description,
+                    text = "${type}•${puntuation ?: "N/A"}•${distance}km",
                     style = MaterialTheme.typography.bodyMedium.copy(
-                        color = Color(0xFF6E6E6E)
+                        color = colorResource(R.color.grey)
                     )
                 )
             }
 
-            // Icono de flecha
+            // 🔹 Flecha alineada a la derecha y centrada verticalmente
             Icon(
                 imageVector = Icons.Default.ChevronRight,
                 contentDescription = "Ver más",
-                tint = Color(0xFF6E6E6E)
+                tint = colorResource(R.color.grey),
+                modifier = Modifier.size(24.dp)
             )
         }
     }

--- a/app/src/main/java/com/example/myapplication/ui/screens/user/tabs/Favorites.kt
+++ b/app/src/main/java/com/example/myapplication/ui/screens/user/tabs/Favorites.kt
@@ -1,15 +1,30 @@
 package com.example.myapplication.ui.screens.user.tabs
 
 import TopBar
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowBackIosNew
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,21 +32,34 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import co.edu.eam.lugaresapp.ui.user.bottombar.BottomBarUser
+import com.example.myapplication.R
 import com.example.myapplication.config.Navigation
+import com.example.myapplication.ui.components.Button
 import com.example.myapplication.ui.components.CompactSearchBar
 import com.example.myapplication.ui.components.FavoriteTopBar
+import com.example.myapplication.ui.screens.user.navs.UserRouteTab
 
 @Composable
 fun Favoritos(navController: NavHostController){
     var query by rememberSaveable { mutableStateOf("") }
 
     Scaffold(
-        modifier = Modifier.fillMaxSize(),
+
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+        ,
         topBar = {
             FavoriteTopBar(
                 navController,
@@ -41,18 +69,47 @@ fun Favoritos(navController: NavHostController){
             )
         },
         bottomBar = {
-            BottomBarUser(
-                navController = navController,
-                showTopBar = { },
-                showFAB = { },
-                titleTopBar = { }
-            )
+            Row (
+                Modifier.padding(10.dp)
+            ){
+                Button(
+                    onClick = { },
+                    modifier = Modifier
+                        .width(160.dp)
+                        .clip(RoundedCornerShape(222.dp)),
+                    text = stringResource(R.string.Gestionar_Listas),
+                    color = colorResource(R.color.lightgreen),
+                    contentColor = colorResource(R.color.black)
+                )
+                Button(
+                    onClick = { navController.navigate(UserRouteTab.HomeUser::class.qualifiedName!!) {
+                        popUpTo(navController.graph.startDestinationId)
+                        launchSingleTop = true
+                    }
+                    },
+                    modifier = Modifier
+                        .width(120.dp)
+                        .clip(RoundedCornerShape(222.dp)),
+                    text = stringResource(R.string.Abrir_Mapa),
+                    color = colorResource(R.color.green),
+                    contentColor = colorResource(R.color.white)
+                )
+            }
+
+
+
         },
     ) { innerPadding ->
-        Column(modifier = Modifier.padding(innerPadding)) {
+        Column(modifier = Modifier
+            .background(Color.White)
+            .padding(innerPadding)
+
+
+
+        ) {
             Divider(
                 modifier = Modifier.padding(vertical = 2.dp),
-                color = Color.Gray,
+                color = Color.LightGray,
                 thickness = 1.dp
             )
 
@@ -63,9 +120,122 @@ fun Favoritos(navController: NavHostController){
             )
             Divider(
                 modifier = Modifier.padding(vertical = 2.dp),
-                color = Color.Gray,
+                color = Color.LightGray,
                 thickness = 1.dp
             )
+            LazyRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                item {
+                    Button(
+                        onClick = {query="" },
+
+                        modifier = Modifier
+                            .width(70.dp)
+                            .clip(RoundedCornerShape(22.dp)),
+                        text = "All",
+                        color = colorResource(R.color.lightgreen),
+                        contentColor = colorResource(R.color.teal_700)
+                    )
+                }
+                item {
+                    Button(
+                        onClick = {query="Restaurant" },
+
+                        modifier = Modifier
+                            .width(120.dp)
+                            .clip(RoundedCornerShape(22.dp)),
+                        text = "Restaurant",
+                        color = colorResource(R.color.lightgreen),
+                        contentColor = colorResource(R.color.teal_700)
+                    )
+                }
+                item {
+                    Button(
+                        onClick = {query="Bar" },
+
+                        modifier = Modifier
+                            .width(70.dp)
+                            .clip(RoundedCornerShape(22.dp)),
+                        text = "Bar",
+                        color = colorResource(R.color.lightgreen),
+                        contentColor = colorResource(R.color.teal_700)
+                    )
+                }
+            }
+            Divider(
+                modifier = Modifier.padding(vertical = 2.dp),
+                color = Color.LightGray,
+                thickness = 1.dp
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(120.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(colorResource(R.color.lightgreen)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.FavoriteBorder,
+                        contentDescription = "Sin favoritos",
+                        tint = Color.Gray,
+                        modifier = Modifier.size(50.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+
+                Text(
+                    text = "Aún no tienes favoritos",
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color.Black
+                    )
+                )
+
+                Spacer(modifier = Modifier.height(6.dp))
+
+
+                Text(
+                    text = "Toca el ícono de corazón en un lugar para guardarlo aquí.",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = Color.Gray
+                    ),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Button(
+                    onClick = {  },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = colorResource(R.color.green)
+                    ),
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier
+                        .width(200.dp)
+                        .height(48.dp)
+                ) {
+                    Text(
+                        text = "Explorar lugares",
+                        color = Color.White,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+
 
         }
     }

--- a/app/src/main/java/com/example/myapplication/viewmodel/PlacesViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/viewmodel/PlacesViewModel.kt
@@ -60,7 +60,9 @@ class PlacesViewModel: ViewModel() {
                     Schedule(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(20, 0)),
                     Schedule(DayOfWeek.THURSDAY, LocalTime.of(10, 0), LocalTime.of(20, 0)),
                     Schedule(DayOfWeek.FRIDAY, LocalTime.of(10, 0), LocalTime.of(20, 0)),
-                )
+                ),
+                distanceKm = 15.5,
+                puntuation = 4.7,
             ),
             Place(
                 id = "2",
@@ -73,6 +75,8 @@ class PlacesViewModel: ViewModel() {
                 type = PlaceType.BAR,
                 city = City.ARMENIA,
                 schedules = listOf(),
+                distanceKm = 10.5,
+                puntuation = 2.8,
                 createdByUserId = "2"
             ),
             Place(
@@ -86,6 +90,8 @@ class PlacesViewModel: ViewModel() {
                 type = PlaceType.HOTEL,
                 city = City.PEREIRA,
                 schedules = listOf(),
+                distanceKm = 35.0,
+                puntuation = 2.0,
                 createdByUserId = "2"
             ),
             Place(
@@ -99,6 +105,8 @@ class PlacesViewModel: ViewModel() {
                 type = PlaceType.SHOPPING,
                 city = City.MEDELLIN,
                 schedules = listOf(),
+                distanceKm = 5.5,
+                puntuation = 4.5,
                 createdByUserId = "2"
             ),
             Place(
@@ -112,6 +120,8 @@ class PlacesViewModel: ViewModel() {
                 type = PlaceType.SHOPPING,
                 city = City.BOGOTA,
                 schedules = listOf(),
+                distanceKm = 25.0,
+                puntuation = 4.0,
                 createdByUserId = "2"
             ),
             Place(
@@ -125,6 +135,8 @@ class PlacesViewModel: ViewModel() {
                 type = PlaceType.PARK,
                 city = City.BOGOTA,
                 schedules = listOf(),
+                distanceKm = 45.1,
+                puntuation = 3.8,
                 createdByUserId = "2"
             )
         )
@@ -142,7 +154,8 @@ class PlacesViewModel: ViewModel() {
 
     fun findByName(name: String): List<Place> =
         _places.value.filter { it.title.contains(other = name, ignoreCase = true) }
-
+    fun findByKM(km: Double): List<Place> =
+        _places.value.filter { it.distanceKm!! <= km}
 
     fun approvePlace(id: String) {
         _places.value = _places.value.map { p ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,5 +38,8 @@
     <string name="Favoritos">Favoritos</string>
     <string name="txt_search">Busca por nombre</string>
     <string name="Lugares_cerca">Resultados cerca de ti</string>
+    <!-- Content Favorites -->
+    <string name="Gestionar_Listas">Gestionar Listas</string>
+    <string name="Abrir_Mapa">Abrir Mapa</string>
 
 </resources>


### PR DESCRIPTION
This commit introduces significant UI/UX enhancements to the Home and Favorites screens, along with data model and functionality updates.

**Key Changes:**

- **Place Model:**

  - Added distanceKm and puntuation properties to the Place data class to store distance and rating information.

  - Updated mock data in PlacesViewModel to include these new fields.

- **HomeUser Screen:**

  - Implemented filter buttons for Restaurant, Shopping, 1-20km, and Open.

  - Replaced slipCard with new SlipCard component showing type, rating, and distance.

  - Improved UI layout with full-screen map and floating panel for nearby places.

- **Favorites Screen:**

  - Redesigned with empty state, filters, and new bottom buttons (Manage Lists, Open Map).

- **General:**

  - Added findByKM function in PlacesViewModel for distance filtering.

  - Locked screen orientation to portrait in AndroidManifest.xml.